### PR TITLE
declaration: Add basic declaration for Typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default function(name: string): boolean; 


### PR DESCRIPTION
Basic Typescript declaration, further documentation might be needed. This will work whether the compiler has `esModuleInterop` true or not.